### PR TITLE
Expose XorRelayAddress in client API, adjust example

### DIFF
--- a/examples/turncli.rs
+++ b/examples/turncli.rs
@@ -52,6 +52,8 @@ fn main() -> Result<(), trackable::error::MainError> {
     )))?;
     eprintln!("# ALLOCATED: server={:?}", server_addr);
 
+    eprintln!("Relay address is {:?}", client.relay_addr());
+
     let use_channel_data = opt.use_channel_data;
     let client = track!(fibers_global::execute(
         wait(client, move |client| if use_channel_data {

--- a/src/client/allocate.rs
+++ b/src/client/allocate.rs
@@ -68,6 +68,7 @@ where
         match response {
             Ok(response) => {
                 let mut lifetime = None;
+                let mut relay_addr = None;
                 for attr in response.attributes() {
                     match attr {
                         Attribute::Lifetime(a) => {
@@ -76,16 +77,20 @@ where
                         Attribute::MessageIntegrity(a) => {
                             track!(self.auth_params.validate(&a))?;
                         }
+                        Attribute::XorRelayAddress(a) => {
+                            relay_addr = Some(a.address());
+                        }
                         _ => {}
                     }
                 }
 
                 let lifetime = track_assert_some!(lifetime, ErrorKind::Other; response);
-                let client = ClientCore::new(
+                let mut client = ClientCore::new(
                     self.stun_channel.take().expect("never fails"),
                     self.channel_data_transporter.take().expect("never fails"),
                     self.auth_params.clone(),
                     lifetime,
+                    relay_addr,
                 );
                 Ok(Some(client))
             }

--- a/src/client/core.rs
+++ b/src/client/core.rs
@@ -37,6 +37,7 @@ where
     refresh_transaction: StunTransaction,
     create_permission_transaction: StunTransaction<(SocketAddr, Response<Attribute>)>,
     channel_bind_transaction: StunTransaction<(SocketAddr, Response<Attribute>)>,
+    pub relay_addr: Option<SocketAddr>,
 }
 impl<S, C> ClientCore<S, C>
 where
@@ -60,6 +61,7 @@ where
         channel_data_transporter: C,
         auth_params: AuthParams,
         lifetime: Duration,
+        relay_addr: Option<SocketAddr>,
     ) -> Self {
         let mut timeout_queue = TimeoutQueue::new();
         timeout_queue.push(TimeoutEntry::Refresh, lifetime * 10 / 9);
@@ -75,6 +77,7 @@ where
             refresh_transaction: StunTransaction::empty(),
             create_permission_transaction: StunTransaction::empty(),
             channel_bind_transaction: StunTransaction::empty(),
+            relay_addr,
         }
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -96,6 +96,10 @@ impl TcpClient {
                 track_err!(ClientCore::allocate(stun, channel_data, auth_params))
             }).map(TcpClient)
     }
+    
+    pub fn relay_addr(&self) -> Option<SocketAddr> {
+        self.0.relay_addr
+    }
 }
 unsafe impl Send for TcpClient {}
 impl Client for TcpClient {
@@ -152,6 +156,10 @@ impl UdpClient {
                 let channel_data = FixedPeerTransporter::new((), server_addr, channel_data);
                 track_err!(ClientCore::allocate(stun, channel_data, auth_params))
             }).map(UdpClient)
+    }
+
+    pub fn relay_addr(&self) -> Option<SocketAddr> {
+        self.0.relay_addr
     }
 }
 unsafe impl Send for UdpClient {}


### PR DESCRIPTION
This is a critical parameter for using TURN for NAT traversal, the demo is more useful with this.